### PR TITLE
Music parsing

### DIFF
--- a/dispersing/kaitai_parsers/summoning_resources.py
+++ b/dispersing/kaitai_parsers/summoning_resources.py
@@ -138,7 +138,13 @@ class SummoningResources(KaitaiStruct):
                 self.header = SummoningResources.GenericHeader(self.header_size, self._io, self, self._root)
             self._debug['header']['end'] = self._io.pos()
             self._debug['contents']['start'] = self._io.pos()
-            self.contents = self._io.read_bytes((self.record_end - self._root._io.pos()))
+            _on = self.type
+            if _on == SummoningResources.RecordTypes.music:
+                self._raw_contents = self._io.read_bytes((self.record_end - self._root._io.pos()))
+                _io__raw_contents = KaitaiStream(BytesIO(self._raw_contents))
+                self.contents = SummoningResources.MusicContents(_io__raw_contents, self, self._root)
+            else:
+                self.contents = self._io.read_bytes((self.record_end - self._root._io.pos()))
             self._debug['contents']['end'] = self._io.pos()
 
         @property
@@ -158,6 +164,322 @@ class SummoningResources(KaitaiStruct):
             return self._m_record_end if hasattr(self, '_m_record_end') else None
 
 
+    class TrackEvent(KaitaiStruct):
+        SEQ_FIELDS = ["v_time", "event_header", "event_body"]
+        def __init__(self, i, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self.i = i
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['v_time']['start'] = self._io.pos()
+            self.v_time = SummoningResources.OverflowTime(self._io, self, self._root)
+            self._debug['v_time']['end'] = self._io.pos()
+            if self.first_byte > 127:
+                self._debug['event_header']['start'] = self._io.pos()
+                self.event_header = self._io.read_u1()
+                self._debug['event_header']['end'] = self._io.pos()
+
+            self._debug['event_body']['start'] = self._io.pos()
+            _on = self.event_type
+            if _on == 224:
+                self.event_body = SummoningResources.PitchBendEvent(self._io, self, self._root)
+            elif _on == 144:
+                self.event_body = SummoningResources.NoteOnEvent(self._io, self, self._root)
+            elif _on == 208:
+                self.event_body = SummoningResources.ChannelPressureEvent(self._io, self, self._root)
+            elif _on == 192:
+                self.event_body = SummoningResources.ProgramChangeEvent(self._io, self, self._root)
+            elif _on == 160:
+                self.event_body = SummoningResources.PolyphonicPressureEvent(self._io, self, self._root)
+            elif _on == 176:
+                self.event_body = SummoningResources.ControllerEvent(self._io, self, self._root)
+            elif _on == 240:
+                self.event_body = SummoningResources.SystemEvent(self._io, self, self._root)
+            elif _on == 128:
+                self.event_body = SummoningResources.NoteOffEvent(self._io, self, self._root)
+            self._debug['event_body']['end'] = self._io.pos()
+
+        @property
+        def first_byte(self):
+            if hasattr(self, '_m_first_byte'):
+                return self._m_first_byte if hasattr(self, '_m_first_byte') else None
+
+            _pos = self._io.pos()
+            self._io.seek(self._io.pos())
+            self._debug['_m_first_byte']['start'] = self._io.pos()
+            self._m_first_byte = self._io.read_u1()
+            self._debug['_m_first_byte']['end'] = self._io.pos()
+            self._io.seek(_pos)
+            return self._m_first_byte if hasattr(self, '_m_first_byte') else None
+
+        @property
+        def event_type(self):
+            if hasattr(self, '_m_event_type'):
+                return self._m_event_type if hasattr(self, '_m_event_type') else None
+
+            self._m_event_type = ((self.first_byte & 240) if self.first_byte > 127 else self._parent.music_commands[(self.i - 1)].event_type)
+            return self._m_event_type if hasattr(self, '_m_event_type') else None
+
+        @property
+        def channel(self):
+            if hasattr(self, '_m_channel'):
+                return self._m_channel if hasattr(self, '_m_channel') else None
+
+            self._m_channel = ((self.first_byte & 15) if self.first_byte > 127 else self._parent.music_commands[(self.i - 1)].channel)
+            return self._m_channel if hasattr(self, '_m_channel') else None
+
+
+    class MusicContents(KaitaiStruct):
+        SEQ_FIELDS = ["instruments", "music_commands"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['instruments']['start'] = self._io.pos()
+            self.instruments = [None] * (self._parent.header.i_inst_count)
+            for i in range(self._parent.header.i_inst_count):
+                if not 'arr' in self._debug['instruments']:
+                    self._debug['instruments']['arr'] = []
+                self._debug['instruments']['arr'].append({'start': self._io.pos()})
+                self.instruments[i] = SummoningResources.InstrumentParameters(self._io, self, self._root)
+                self._debug['instruments']['arr'][i]['end'] = self._io.pos()
+
+            self._debug['instruments']['end'] = self._io.pos()
+            self._debug['music_commands']['start'] = self._io.pos()
+            self.music_commands = []
+            i = 0
+            while not self._io.is_eof():
+                if not 'arr' in self._debug['music_commands']:
+                    self._debug['music_commands']['arr'] = []
+                self._debug['music_commands']['arr'].append({'start': self._io.pos()})
+                self.music_commands.append(SummoningResources.TrackEvent(i, self._io, self, self._root))
+                self._debug['music_commands']['arr'][len(self.music_commands) - 1]['end'] = self._io.pos()
+                i += 1
+
+            self._debug['music_commands']['end'] = self._io.pos()
+
+        @property
+        def contents(self):
+            if hasattr(self, '_m_contents'):
+                return self._m_contents if hasattr(self, '_m_contents') else None
+
+            _pos = self._io.pos()
+            self._io.seek(0)
+            self._debug['_m_contents']['start'] = self._io.pos()
+            self._m_contents = self._io.read_bytes_full()
+            self._debug['_m_contents']['end'] = self._io.pos()
+            self._io.seek(_pos)
+            return self._m_contents if hasattr(self, '_m_contents') else None
+
+
+    class StopEvent(KaitaiStruct):
+        SEQ_FIELDS = []
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            pass
+
+
+    class PitchBendEvent(KaitaiStruct):
+        SEQ_FIELDS = ["b1", "b2"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['b1']['start'] = self._io.pos()
+            self.b1 = self._io.read_u1()
+            self._debug['b1']['end'] = self._io.pos()
+            self._debug['b2']['start'] = self._io.pos()
+            self.b2 = self._io.read_u1()
+            self._debug['b2']['end'] = self._io.pos()
+
+        @property
+        def bend_value(self):
+            if hasattr(self, '_m_bend_value'):
+                return self._m_bend_value if hasattr(self, '_m_bend_value') else None
+
+            self._m_bend_value = (((self.b2 << 7) + self.b1) - 16384)
+            return self._m_bend_value if hasattr(self, '_m_bend_value') else None
+
+        @property
+        def adj_bend_value(self):
+            if hasattr(self, '_m_adj_bend_value'):
+                return self._m_adj_bend_value if hasattr(self, '_m_adj_bend_value') else None
+
+            self._m_adj_bend_value = (self.bend_value - 16384)
+            return self._m_adj_bend_value if hasattr(self, '_m_adj_bend_value') else None
+
+
+    class ProgramChangeEvent(KaitaiStruct):
+        SEQ_FIELDS = ["program"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['program']['start'] = self._io.pos()
+            self.program = self._io.read_u1()
+            self._debug['program']['end'] = self._io.pos()
+
+
+    class Empty(KaitaiStruct):
+        SEQ_FIELDS = []
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            pass
+
+
+    class NoteOnEvent(KaitaiStruct):
+        SEQ_FIELDS = ["note", "volume"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['note']['start'] = self._io.pos()
+            self.note = self._io.read_u1()
+            self._debug['note']['end'] = self._io.pos()
+            self._debug['volume']['start'] = self._io.pos()
+            self.volume = self._io.read_u1()
+            self._debug['volume']['end'] = self._io.pos()
+
+
+    class PolyphonicPressureEvent(KaitaiStruct):
+        SEQ_FIELDS = ["volume"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['volume']['start'] = self._io.pos()
+            self.volume = self._io.read_u1()
+            self._debug['volume']['end'] = self._io.pos()
+
+
+    class ControllerEvent(KaitaiStruct):
+        SEQ_FIELDS = ["controller", "value"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['controller']['start'] = self._io.pos()
+            self.controller = self._io.read_u1()
+            self._debug['controller']['end'] = self._io.pos()
+            self._debug['value']['start'] = self._io.pos()
+            self.value = self._io.read_u1()
+            self._debug['value']['end'] = self._io.pos()
+
+
+    class TempoMultiplierEvent(KaitaiStruct):
+        SEQ_FIELDS = ["event_start", "integer_part", "fractional_part", "event_end"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['event_start']['start'] = self._io.pos()
+            self.event_start = self._io.read_bytes(2)
+            self._debug['event_start']['end'] = self._io.pos()
+            if not self.event_start == b"\x7F\x00":
+                raise kaitaistruct.ValidationNotEqualError(b"\x7F\x00", self.event_start, self._io, u"/types/tempo_multiplier_event/seq/0")
+            self._debug['integer_part']['start'] = self._io.pos()
+            self.integer_part = self._io.read_u1()
+            self._debug['integer_part']['end'] = self._io.pos()
+            self._debug['fractional_part']['start'] = self._io.pos()
+            self.fractional_part = self._io.read_u1()
+            self._debug['fractional_part']['end'] = self._io.pos()
+            self._debug['event_end']['start'] = self._io.pos()
+            self.event_end = self._io.read_bytes(1)
+            self._debug['event_end']['end'] = self._io.pos()
+            if not self.event_end == b"\xF7":
+                raise kaitaistruct.ValidationNotEqualError(b"\xF7", self.event_end, self._io, u"/types/tempo_multiplier_event/seq/3")
+
+
+    class InstrumentParameters(KaitaiStruct):
+        SEQ_FIELDS = ["opl_modulator", "opl_carrier", "i_mod_wave_sel", "i_car_wave_sel", "extra"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['opl_modulator']['start'] = self._io.pos()
+            self.opl_modulator = SummoningResources.SndOplregs(self._io, self, self._root)
+            self._debug['opl_modulator']['end'] = self._io.pos()
+            self._debug['opl_carrier']['start'] = self._io.pos()
+            self.opl_carrier = SummoningResources.SndOplregs(self._io, self, self._root)
+            self._debug['opl_carrier']['end'] = self._io.pos()
+            self._debug['i_mod_wave_sel']['start'] = self._io.pos()
+            self.i_mod_wave_sel = self._io.read_u2le()
+            self._debug['i_mod_wave_sel']['end'] = self._io.pos()
+            self._debug['i_car_wave_sel']['start'] = self._io.pos()
+            self.i_car_wave_sel = self._io.read_u2le()
+            self._debug['i_car_wave_sel']['end'] = self._io.pos()
+            self._debug['extra']['start'] = self._io.pos()
+            self.extra = self._io.read_u2le()
+            self._debug['extra']['end'] = self._io.pos()
+
+
+    class SystemEvent(KaitaiStruct):
+        SEQ_FIELDS = ["event_body"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['event_body']['start'] = self._io.pos()
+            _on = self._parent.channel
+            if _on == 0:
+                self.event_body = SummoningResources.TempoMultiplierEvent(self._io, self, self._root)
+            elif _on == 12:
+                self.event_body = SummoningResources.StopEvent(self._io, self, self._root)
+            self._debug['event_body']['end'] = self._io.pos()
+
+
     class GenericHeader(KaitaiStruct):
         SEQ_FIELDS = ["contents"]
         def __init__(self, size, _io, _parent=None, _root=None):
@@ -172,6 +494,58 @@ class SummoningResources(KaitaiStruct):
             self._debug['contents']['start'] = self._io.pos()
             self.contents = self._io.read_bytes(self.size)
             self._debug['contents']['end'] = self._io.pos()
+
+
+    class OverflowTime(KaitaiStruct):
+        SEQ_FIELDS = ["groups"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['groups']['start'] = self._io.pos()
+            self.groups = []
+            i = 0
+            while True:
+                if not 'arr' in self._debug['groups']:
+                    self._debug['groups']['arr'] = []
+                self._debug['groups']['arr'].append({'start': self._io.pos()})
+                _ = self._io.read_u1()
+                self.groups.append(_)
+                self._debug['groups']['arr'][len(self.groups) - 1]['end'] = self._io.pos()
+                if _ != 248:
+                    break
+                i += 1
+            self._debug['groups']['end'] = self._io.pos()
+
+        @property
+        def value(self):
+            if hasattr(self, '_m_value'):
+                return self._m_value if hasattr(self, '_m_value') else None
+
+            self._m_value = (((len(self.groups) - 1) * 240) + self.groups[-1])
+            return self._m_value if hasattr(self, '_m_value') else None
+
+
+    class NoteOffEvent(KaitaiStruct):
+        SEQ_FIELDS = ["note", "volume"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['note']['start'] = self._io.pos()
+            self.note = self._io.read_u1()
+            self._debug['note']['end'] = self._io.pos()
+            self._debug['volume']['start'] = self._io.pos()
+            self.volume = self._io.read_u1()
+            self._debug['volume']['end'] = self._io.pos()
 
 
     class MusicHeader(KaitaiStruct):
@@ -244,6 +618,72 @@ class SummoningResources(KaitaiStruct):
             self._debug['font_sprite_header']['start'] = self._io.pos()
             self.font_sprite_header = SummoningResources.SpriteHeader(self._io, self, self._root)
             self._debug['font_sprite_header']['end'] = self._io.pos()
+
+
+    class SndOplregs(KaitaiStruct):
+        SEQ_FIELDS = ["ksl", "multiple", "feedback", "attack", "sustain", "eg", "decay", "release_rate", "total_level", "am", "vib", "ksr", "con"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['ksl']['start'] = self._io.pos()
+            self.ksl = self._io.read_u2le()
+            self._debug['ksl']['end'] = self._io.pos()
+            self._debug['multiple']['start'] = self._io.pos()
+            self.multiple = self._io.read_u2le()
+            self._debug['multiple']['end'] = self._io.pos()
+            self._debug['feedback']['start'] = self._io.pos()
+            self.feedback = self._io.read_u2le()
+            self._debug['feedback']['end'] = self._io.pos()
+            self._debug['attack']['start'] = self._io.pos()
+            self.attack = self._io.read_u2le()
+            self._debug['attack']['end'] = self._io.pos()
+            self._debug['sustain']['start'] = self._io.pos()
+            self.sustain = self._io.read_u2le()
+            self._debug['sustain']['end'] = self._io.pos()
+            self._debug['eg']['start'] = self._io.pos()
+            self.eg = self._io.read_u2le()
+            self._debug['eg']['end'] = self._io.pos()
+            self._debug['decay']['start'] = self._io.pos()
+            self.decay = self._io.read_u2le()
+            self._debug['decay']['end'] = self._io.pos()
+            self._debug['release_rate']['start'] = self._io.pos()
+            self.release_rate = self._io.read_u2le()
+            self._debug['release_rate']['end'] = self._io.pos()
+            self._debug['total_level']['start'] = self._io.pos()
+            self.total_level = self._io.read_u2le()
+            self._debug['total_level']['end'] = self._io.pos()
+            self._debug['am']['start'] = self._io.pos()
+            self.am = self._io.read_u2le()
+            self._debug['am']['end'] = self._io.pos()
+            self._debug['vib']['start'] = self._io.pos()
+            self.vib = self._io.read_u2le()
+            self._debug['vib']['end'] = self._io.pos()
+            self._debug['ksr']['start'] = self._io.pos()
+            self.ksr = self._io.read_u2le()
+            self._debug['ksr']['end'] = self._io.pos()
+            self._debug['con']['start'] = self._io.pos()
+            self.con = self._io.read_u2le()
+            self._debug['con']['end'] = self._io.pos()
+
+
+    class ChannelPressureEvent(KaitaiStruct):
+        SEQ_FIELDS = ["pressure"]
+        def __init__(self, _io, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root if _root else self
+            self._debug = collections.defaultdict(dict)
+            self._read()
+
+        def _read(self):
+            self._debug['pressure']['start'] = self._io.pos()
+            self.pressure = self._io.read_u1()
+            self._debug['pressure']['end'] = self._io.pos()
 
 
 

--- a/dispersing/ksy_files/summoning_resources.ksy
+++ b/dispersing/ksy_files/summoning_resources.ksy
@@ -35,6 +35,10 @@ types:
             record_types::music: music_header
             _: generic_header(header_size)
       - id: contents
+        type:
+          switch-on: type
+          cases:
+            record_types::music: music_contents
         size: record_end - _root._io.pos
     instances:
       record_start:
@@ -99,12 +103,19 @@ types:
         type: u1
       - id: i_inst_count
         type: u1
+  music_contents:
+    seq:
       - id: instruments
         type: instrument_parameters
         repeat: expr
-        repeat-expr: i_inst_count
+        repeat-expr: _parent.header.as<music_header>.i_inst_count
       - id: music_commands
-        size: data_size
+        type: track_event(_index)
+        repeat: eos
+    instances:
+      contents:
+        pos: 0
+        size-eos: true
   generic_header:
     params:
       - id: size
@@ -152,6 +163,110 @@ types:
         type: u2le
       - id: con
         type: u2le
+  track_event:
+    params:
+      - id: i
+        type: u4
+    seq:
+      - id: v_time
+        type: overflow_time
+      - id: event_header
+        if: first_byte > 0x7f
+        type: u1
+      - id: event_body
+        type:
+          switch-on: event_type
+          cases:
+            0x80: note_off_event
+            0x90: note_on_event
+            0xa0: polyphonic_pressure_event
+            0xb0: controller_event
+            0xc0: program_change_event
+            0xd0: channel_pressure_event
+            0xe0: pitch_bend_event
+            # the only system exclusive event supported here is tempo
+            0xf0: system_event
+    instances:
+      first_byte:
+        type: u1
+        pos: _io.pos
+      event_type:
+        value: 'first_byte > 0x7f ? first_byte & 0xf0 : _parent.music_commands[i - 1].event_type.as<u1>'
+      channel:
+        value: 'first_byte > 0x7f ? first_byte & 0xf : _parent.music_commands[i - 1].channel.as<u1>'
+  empty:
+    seq: []
+  system_event:
+    seq:
+      - id: event_body
+        type:
+          switch-on: _parent.channel
+          cases:
+            0x0: tempo_multiplier_event
+            0xc: stop_event
+  stop_event:
+    seq: []
+  tempo_multiplier_event:
+    seq:
+      - id: event_start
+        contents: [0x7F, 0x00]
+      - id: integer_part
+        type: u1
+      - id: fractional_part
+        type: u1
+      - id: event_end
+        contents: [0xf7]
+  note_off_event:
+    seq:
+      - id: note
+        type: u1
+      - id: volume
+        type: u1
+  note_on_event:
+    seq:
+      - id: note
+        type: u1
+      - id: volume
+        type: u1
+  polyphonic_pressure_event:
+    seq:
+      - id: volume
+        type: u1
+  controller_event:
+    seq:
+      - id: controller
+        type: u1
+      - id: value
+        type: u1
+  program_change_event:
+    seq:
+      - id: program
+        type: u1
+  channel_pressure_event:
+    seq:
+      - id: pressure
+        type: u1
+  pitch_bend_event:
+    seq:
+      - id: b1
+        type: u1
+      - id: b2
+        type: u1
+    instances:
+      bend_value:
+        value: (b2 << 7) + b1 - 0x4000
+      adj_bend_value:
+        value: bend_value - 0x4000
+  overflow_time:
+    # based on the vlq kaitai formats
+    seq:
+      - id: groups
+        type: u1
+        repeat: until
+        repeat-until: _ != 0xf8
+    instances:
+      value:
+        value: (groups.size - 1) * 240 + groups[-1]
 enums:
   record_types:
     1: sprite

--- a/dispersing/ksy_files/summoning_resources.ksy
+++ b/dispersing/ksy_files/summoning_resources.ksy
@@ -99,6 +99,12 @@ types:
         type: u1
       - id: i_inst_count
         type: u1
+      - id: instruments
+        type: instrument_parameters
+        repeat: expr
+        repeat-expr: i_inst_count
+      - id: music_commands
+        size: data_size
   generic_header:
     params:
       - id: size
@@ -106,6 +112,44 @@ types:
     seq:
       - id: contents
         size: size
+  instrument_parameters:
+    seq:
+      - id: opl_modulator
+        type: snd_oplregs
+      - id: opl_carrier
+        type: snd_oplregs
+      - id: i_mod_wave_sel
+        type: u2le
+      - id: i_car_wave_sel
+        type: u2le
+  snd_oplregs:
+    seq:
+      - id: ksl
+        type: u2le
+      - id: multiple
+        type: u2le
+      - id: feedback
+        type: u2le
+      - id: attack
+        type: u2le
+      - id: sustain
+        type: u2le
+      - id: eg
+        type: u2le
+      - id: decay
+        type: u2le
+      - id: release_rate
+        type: u2le
+      - id: total_level
+        type: u2le
+      - id: am
+        type: u2le
+      - id: vib
+        type: u2le
+      - id: ksr
+        type: u2le
+      - id: con
+        type: u2le
 enums:
   record_types:
     1: sprite

--- a/dispersing/ksy_files/summoning_resources.ksy
+++ b/dispersing/ksy_files/summoning_resources.ksy
@@ -122,6 +122,8 @@ types:
         type: u2le
       - id: i_car_wave_sel
         type: u2le
+      - id: extra
+        type: u2le
   snd_oplregs:
     seq:
       - id: ksl

--- a/dispersing/resource_files.py
+++ b/dispersing/resource_files.py
@@ -11,6 +11,7 @@ class ResourceMap:
         self.fonts = {}
         self.sprites = {}
         self.palette_sprites = {}
+        self.music = {}
         palettes = game.palettes
         for i, rec in enumerate(game.assets["RESOURCE"].records):
             self.records.append(rec)
@@ -18,6 +19,8 @@ class ResourceMap:
                 self.sprites[i] = SpriteResource(rec, palettes)
             elif rec.type.name == "font":
                 self.fonts[i] = FontResource(rec, palettes)
+            elif rec.type.name == "music":
+                self.music[i] = rec
 
     def palettes_to_array(self):
         # Note that these run 0 .. 63, not 0 .. 255.


### PR DESCRIPTION
This implements parsing of the MUS and SND components of the RESOURCE file, which corresponds to resource type 3.

The MUS file format is based initially on the Standard MIDI 1.0 that comes with Kaitai, but with a few modifications to account for it actually being a dialect of AdLib MUS.  It was a little tricky to figure out how to get Kaitai to work with the "continuation" events, wherein a new status is not emitted (but timing *is*) if the status isn't actually changing.  This would show up, for instance, in rapid oscillations of notes like NoteOn and NoteOff on the same channel and note.  Instead of repeatedly issuing the `0x90` event, it would issue the timing, then the event, then the two bytes for the signal, and then another timing and the two bytes.  This evaded my detection for a bit!

The SND component was fairly straightforward in comparison, but I'm not entirely sure what the extra parameters in the instrument definitions are.
